### PR TITLE
Add implementation of ServerRequestInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ Read a line from the stream up to the maximum allowed buffer length.
 Parses a request message string into a request object.
 
 
+## `function parse_server_request`
+
+`function parse_server_request($message, array $serverParams = array())`
+
+Parses a request message string into a server-side request object.
+
+
 ## `function parse_response`
 
 `function parse_response($message)`

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace RingCentral\Psr7;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RingCentral\Psr7\Request;
+
+/**
+ * PSR-7 server-side request implementation.
+ */
+class ServerRequest extends Request implements ServerRequestInterface
+{
+    private $attributes = array();
+
+    private $serverParams = array();
+    private $fileParams = array();
+    private $cookies = array();
+    private $queryParams = array();
+    private $parsedBody = null;
+
+    /**
+     * @param null|string $method HTTP method for the request.
+     * @param null|string|UriInterface $uri URI for the request.
+     * @param array $headers Headers for the message.
+     * @param string|resource|StreamInterface $body Message body.
+     * @param string $protocolVersion HTTP protocol version.
+     * @param array $serverParams Server params of the request.
+     *
+     * @throws InvalidArgumentException for an invalid URI
+     */
+    public function __construct(
+        $method,
+        $uri,
+        array $headers = array(),
+        $body = null,
+        $protocolVersion = '1.1',
+        $serverParams = array()
+    ) {
+        parent::__construct($method, $uri, $headers, $body, $protocolVersion);
+        $this->serverParams = $serverParams;
+    }
+
+    public function getServerParams()
+    {
+        return $this->serverParams;
+    }
+
+    public function getCookieParams()
+    {
+        return $this->cookies;
+    }
+
+    public function withCookieParams(array $cookies)
+    {
+        $new = clone $this;
+        $new->cookies = $cookies;
+        return $new;
+    }
+
+    public function getQueryParams()
+    {
+        return $this->queryParams;
+    }
+
+    public function withQueryParams(array $query)
+    {
+        $new = clone $this;
+        $new->queryParams = $query;
+        return $new;
+    }
+
+    public function getUploadedFiles()
+    {
+        return $this->fileParams;
+    }
+
+    public function withUploadedFiles(array $uploadedFiles)
+    {
+        $new = clone $this;
+        $new->fileParams = $uploadedFiles;
+        return $new;
+    }
+
+    public function getParsedBody()
+    {
+        return $this->parsedBody;
+    }
+
+    public function withParsedBody($data)
+    {
+        $new = clone $this;
+        $new->parsedBody = $data;
+        return $new;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getAttribute($name, $default = null)
+    {
+        if (!array_key_exists($name, $this->attributes)) {
+            return $default;
+        }
+        return $this->attributes[$name];
+    }
+
+    public function withAttribute($name, $value)
+    {
+        $new = clone $this;
+        $new->attributes[$name] = $value;
+        return $new;
+    }
+
+    public function withoutAttribute($name)
+    {
+        $new = clone $this;
+        unset($new->attributes[$name]);
+        return $new;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -465,6 +465,29 @@ function parse_request($message)
 }
 
 /**
+ * Parses a request message string into a server request object.
+ *
+ * @param string $message Request message string.
+ * @param array $serverParams Server params that will be added to the
+ *                            ServerRequest object
+ *
+ * @return ServerRequest
+ */
+function parse_server_request($message, array $serverParams = array())
+{
+    $request = parse_request($message);
+
+    return new ServerRequest(
+        $request->getMethod(),
+        $request->getUri(),
+        $request->getHeaders(),
+        $request->getBody(),
+        $request->getProtocolVersion(),
+        $serverParams
+    );
+}
+
+/**
  * Parses a response message string into a response object.
  *
  * @param string $message Response message string.

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -583,4 +583,22 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($r1, $r2);
         $this->assertEquals('foo=bar', $r2->getUri()->getQuery());
     }
+
+    public function testServerRequestWithServerParams()
+    {
+        $requestString = "GET /abc HTTP/1.1\r\nHost: foo.com\r\n\r\n";
+        $request = Psr7\parse_server_request($requestString);
+
+        $this->assertEquals(array(), $request->getServerParams());
+    }
+
+    public function testServerRequestWithoutServerParams()
+    {
+        $requestString = "GET /abc HTTP/1.1\r\nHost: foo.com\r\n\r\n";
+        $serverParams = array('server_address' => '127.0.0.1', 'server_port' => 80);
+
+        $request = Psr7\parse_server_request($requestString, $serverParams);
+
+        $this->assertEquals(array('server_address' => '127.0.0.1', 'server_port' => 80), $request->getServerParams());
+    }
 }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use RingCentral\Psr7\ServerRequest;
+
+class ServerRequestTest extends \PHPUnit_Framework_TestCase
+{
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new ServerRequest('GET', 'http://localhost');
+    }
+
+    public function testGetNoAttributes()
+    {
+        $this->assertEquals(array(), $this->request->getAttributes());
+    }
+
+    public function testWithAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('hello' => 'world'), $request->getAttributes());
+    }
+
+    public function testGetAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals('world', $request->getAttribute('hello'));
+    }
+
+    public function testGetDefaultAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(null, $request->getAttribute('hi', null));
+    }
+
+    public function testWithoutAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+        $request = $request->withAttribute('test', 'nice');
+
+        $request = $request->withoutAttribute('hello');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'nice'), $request->getAttributes());
+    }
+
+    public function testWithCookieParams()
+    {
+        $request = $this->request->withCookieParams(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getCookieParams());
+    }
+
+    public function testWithQueryParams()
+    {
+        $request = $this->request->withQueryParams(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getQueryParams());
+    }
+
+    public function testWithUploadedFiles()
+    {
+        $request = $this->request->withUploadedFiles(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getUploadedFiles());
+    }
+
+    public function testWithParsedBody()
+    {
+        $request = $this->request->withParsedBody(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getParsedBody());
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of the [PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface). The new `ServerRequest` is based on the `Request` implementation of this repo.

A following PR will add a function to parse a request string into a `ServerRequest`.