### PR TITLE
[MessageTrait] Fix withAddedHeader() with array $value

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -91,9 +91,18 @@ abstract class MessageTrait
             return $this->withHeader($header, $value);
         }
 
+        $header = trim($header);
+        $name = strtolower($header);
+
+        $value = (array) $value;
+        foreach ($value as &$v) {
+            $v = trim($v);
+        }
+
         $new = clone $this;
-        $new->headers[strtolower($header)][] = $value;
-        $new->headerLines[$header][] = $value;
+        $new->headers[$name] = array_merge($new->headers[$name], $value);
+        $new->headerLines[$header] = array_merge($new->headerLines[$header], $value);
+
         return $new;
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -120,6 +120,14 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Bar, Baz', $r2->getHeaderLine('foo'));
     }
 
+    public function testNewInstanceWhenAddingHeaderArray()
+    {
+        $r = new Response(200, array('Foo' => 'Bar'));
+        $r2 = $r->withAddedHeader('Foo', array('Baz', 'Qux'));
+        $this->assertNotSame($r, $r2);
+        $this->assertEquals(array('Bar', 'Baz', 'Qux'), $r2->getHeader('foo'));
+    }
+
     public function testNewInstanceWhenAddingHeaderThatWasNotThereBefore()
     {
         $r = new Response(200, array('Foo' => 'Bar'));
@@ -142,5 +150,5 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $r = new Response(200, array(), '0');
         $this->assertEquals('0', (string)$r->getBody());
     }
-    
+
 }


### PR DESCRIPTION
This pull request fixes an issue when `withAddedHeader()`'s input param `$value` is an array.  After the changes in this pull request, output will match Guzzle's and Diactoros' output.

Issue example:
```php
<?php

$guzzleResponse = (new GuzzleHttp\Psr7\Response('200', array('test' => 'one')))
    ->withAddedheader('test', array('two'));
echo "Guzzle header: ";
print_r($guzzleResponse->getHeader('test'));

$diactorosResponse = (new Zend\Diactoros\Response('php://memory', 200, array('test' => 'one')))
    ->withAddedheader('test', array('two'));
echo "Diactoros header: ";
print_r($guzzleResponse->getHeader('test'));

$ringCentralResponse = (new RingCentral\Psr7\Response('200', array('test' => 'one')))
    ->withAddedheader('test', array('two'));
echo "RingCentral header: ";
print_r($ringCentralResponse->getHeader('test'));
```

Issue example output:
```
Guzzle header: Array
(
    [0] => one
    [1] => two
)
Diactoros header: Array
(
    [0] => one
    [1] => two
)
RingCentral header: Array
(
    [0] => one
    [1] => Array
        (
            [0] => two
        )

)

```

