### PR TITLE
Fix sprintf format

### DIFF
--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -71,7 +71,7 @@ class LimitStream extends StreamDecoratorTrait implements StreamInterface
     {
         if ($whence !== SEEK_SET || $offset < 0) {
             throw new \RuntimeException(sprintf(
-                'Cannot seek to offset % with whence %s',
+                'Cannot seek to offset %d with whence %s',
                 $offset,
                 $whence
             ));


### PR DESCRIPTION
Using php 8

```
There was 1 error:

1) RingCentral\Tests\Psr7\LimitStreamTest::testAllowsBoundedSeek
ValueError: Unknown format specifier "w"

/dev/shm/BUILDROOT/php-ringcentral-psr7-1.3.0-1.fc33.remi.x86_64/usr/share/php/RingCentral/Psr7/LimitStream.php:74
/dev/shm/BUILD/psr7-360faaec4b563958b673fb52bbe94e37f14bc686/tests/LimitStreamTest.php:84

```